### PR TITLE
Update to provide mol info from param.toml

### DIFF
--- a/src/deepqmc/molecule.py
+++ b/src/deepqmc/molecule.py
@@ -80,10 +80,13 @@ class Molecule(nn.Module):
 
         The available names are in :attr:`Molecule.all_names`.
         """
-        system = deepcopy(_SYSTEMS[name])
-        if name in _SYSTEM_FACTORIES:
-            system.update(_SYSTEM_FACTORIES[name](**kwargs))
+        if set(list(kwargs.keys())) == set(['coords', 'charges', 'charge', 'spin']):
+            system = kwargs
         else:
-            assert not kwargs
+            system = deepcopy(_SYSTEMS[name])
+            if name in _SYSTEM_FACTORIES:
+                system.update(_SYSTEM_FACTORIES[name](**kwargs))
+            else:
+                assert not kwargs
         coords = np.array(system.pop('coords'), dtype=np.float32) * angstrom
         return cls(coords, **system)


### PR DESCRIPTION
Add option to specify the system's information from the param.toml file.
Example:
-----------------
[system]
name = 'H2'
coords = [[0.0, 0.0, 0.0], [3.742, 0.0, 0.0]]
charges = [1, 1]
charge = 0
spin = 0
... 
-----------------
If only the "name" is provided, the system will take the system's data from the predefined (if exist) database (i.e. systems.toml). In case that the 'name' matches a predefined value in systems.toml but all four entries (e.g. coords, charges, charge and spin) are given, the later will be used.